### PR TITLE
Remove un-commented rows and fix ambiguous method call

### DIFF
--- a/bench/micro/micro_boolean_addition.cpp
+++ b/bench/micro/micro_boolean_addition.cpp
@@ -21,7 +21,7 @@ int main(int argc, char** argv) {
     double elapsed;
     gettimeofday(&begin, 0);
 
-    BSharedVector<int> c_1 = orq::ripple_carry_adder(a, b);
+    BSharedVector<int> c_1 = orq::operators::ripple_carry_adder(a, b);
 
     // stop timer
     gettimeofday(&end, 0);
@@ -34,7 +34,7 @@ int main(int argc, char** argv) {
 
     gettimeofday(&begin, 0);
 
-    BSharedVector<int> c_2 = orq::parallel_prefix_adder(a, b);
+    BSharedVector<int> c_2 = orq::operators::parallel_prefix_adder(a, b);
 
     gettimeofday(&end, 0);
     seconds = end.tv_sec - begin.tv_sec;

--- a/bench/micro/micro_ccs_radix.cpp
+++ b/bench/micro/micro_ccs_radix.cpp
@@ -10,8 +10,6 @@ using namespace COMPILED_MPC_PROTOCOL_NAMESPACE;
 #define MAX_ROW_EXPONENT 20
 
 int main(int argc, char** argv) {
-     [executable - threads_num - p_factor -
-    // batch_size]
     orq_init(argc, argv);
     auto pID = runTime->getPartyID();
     int test_size = 1 << 20;

--- a/bench/micro/micro_sorting_rs.cpp
+++ b/bench/micro/micro_sorting_rs.cpp
@@ -16,8 +16,6 @@ using T = int32_t;
 #endif
 
 int main(int argc, char** argv) {
-     [executable - threads_num - p_factor -
-    // batch_size]
     orq_init(argc, argv);
     auto pID = runTime->getPartyID();
     int test_size = 1 << 20;

--- a/examples/ex5_join.cpp
+++ b/examples/ex5_join.cpp
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
         Joined.addColumn("Count");
 
         auto StudentCount = Joined.deepcopy();
-        StudentCount.sort({ENC_TABLE_VALID, "[StudentID]"});
+        StudentCount.sort(std::vector<std::string>{ENC_TABLE_VALID, "[StudentID]"});
         StudentCount.distinct({"[StudentID]"});
         // Count the students
         StudentCount.aggregate({ENC_TABLE_VALID}, {{"Count", "Count", count<A>}});
@@ -151,7 +151,7 @@ int main(int argc, char **argv) {
     {
         auto Joined = Attendees.left_outer_join(Classes, {"[StudentID]"});
 
-        Joined.sort({ENC_TABLE_VALID, "[StudentID]"});
+        Joined.sort(std::vector<std::string>{ENC_TABLE_VALID, "[StudentID]"});
         Joined.distinct({"[StudentID]"});
 
         auto opened = Joined.open_with_schema().first;
@@ -170,7 +170,7 @@ int main(int argc, char **argv) {
         auto Joined = Attendees.right_outer_join(Classes, {"[StudentID]"});
 
         // distinct requires a sort first
-        Joined.sort({ENC_TABLE_VALID, "[StudentID]"});
+        Joined.sort(std::vector<std::string>{ENC_TABLE_VALID, "[StudentID]"});
         Joined.distinct({"[StudentID]"});
 
         auto opened = Joined.open_with_schema().first;
@@ -187,7 +187,7 @@ int main(int argc, char **argv) {
     {
         auto Joined = Attendees.full_outer_join(Classes, {"[StudentID]"});
 
-        Joined.sort({ENC_TABLE_VALID, "[StudentID]"});
+        Joined.sort(std::vector<std::string>{ENC_TABLE_VALID, "[StudentID]"});
         Joined.distinct({"[StudentID]"});
 
         auto opened = Joined.open_with_schema().first;
@@ -208,7 +208,7 @@ int main(int argc, char **argv) {
     {
         auto Joined = Classes.anti_join(Attendees, {"[StudentID]"});
 
-        Joined.sort({ENC_TABLE_VALID, "[StudentID]"});
+        Joined.sort(std::vector<std::string>{ENC_TABLE_VALID, "[StudentID]"});
         Joined.distinct({"[StudentID]"});
 
         auto opened = Joined.open_with_schema().first;
@@ -230,10 +230,10 @@ int main(int argc, char **argv) {
     {
         auto Joined = Classes.semi_join(Attendees, {"[StudentID]"});
 
-        Joined.sort({ENC_TABLE_VALID, "[CourseID]"});
+        Joined.sort(std::vector<std::string>{ENC_TABLE_VALID, "[CourseID]"});
         Joined.distinct({"[CourseID]"});
 
-        Classes.sort({ENC_TABLE_VALID, "[CourseID]"});
+        Classes.sort(std::vector<std::string>{ENC_TABLE_VALID, "[CourseID]"});
         Classes.distinct({"[CourseID]"});
         auto c_count = Classes.open_with_schema().first[0].size();
 


### PR DESCRIPTION
**Function namespace and argument updates:**

* Updated calls to `ripple_carry_adder` and `parallel_prefix_adder` to use the explicit `orq::operators` namespace in `micro_boolean_addition.cpp` for correctness
* Updated all `sort` method calls in `ex5_join.cpp` to explicitly pass a `std::vector<std::string>` instead of using initializer lists,  avoiding ambiguity

**Code cleanup:**

* Removed outdated usage comments from the beginning of `main` functions in `micro_ccs_radix.cpp` and `micro_sorting_rs.cpp`

**Compiler Output:**

```bash
user@machine:~/orq/build$ make -j 16
```
```
/home/user/orq/bench/micro/micro_boolean_addition.cpp: In function ‘int main(int, char**)’:
/home/user/orq/bench/micro/micro_boolean_addition.cpp:24:35: error: ‘ripple_carry_adder’ is not a member of ‘orq’; did you mean ‘orq::operators::ripple_carry_adder’?
   24 |     BSharedVector<int> c_1 = orq::ripple_carry_adder(a, b);
      |                                   ^~~~~~~~~~~~~~~~~~
```
```
/home/user/orq/examples/ex5_join.cpp: In function ‘int main(int, char**)’:
/home/user/orq/examples/ex5_join.cpp:112:26: error: call of overloaded ‘sort(<brace-enclosed initializer list>)’ is ambiguous
  112 |         StudentCount.sort({ENC_TABLE_VALID, "[StudentID]"});
      |         ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
```

/home/user/orq/bench/micro/micro_ccs_radix.cpp: In function ‘int main(int, char**)’:
/home/user/orq/bench/micro/micro_ccs_radix.cpp:13:7: error: ‘executable’ was not declared in this scope; did you mean ‘execle’?
   13 |      [executable - threads_num - p_factor -
      |       ^~~~~~~~~~
      |       execle
/home/user/orq/bench/micro/micro_ccs_radix.cpp:13:17: error: expected ‘,’ before ‘-’ token
   13 |      [executable - threads_num - p_factor -
      |                 ^~
      |                 ,
/home/user/orq/bench/micro/micro_ccs_radix.cpp:13:18: error: expected identifier before ‘-’ token
   13 |      [executable - threads_num - p_factor -
      |                  ^
/home/user/orq/bench/micro/micro_ccs_radix.cpp:15:25: error: expected ‘]’ before ‘;’ token
   15 |     orq_init(argc, argv);
      |                         ^
      |                         ]
      ```
