### PR TITLE
fix `communicators` field access in RunTime class

### DIFF
--- a/include/backend/common/runtime.h
+++ b/include/backend/common/runtime.h
@@ -971,6 +971,11 @@ class RunTime {
         return ok;
     }
 
+    [[nodiscard]] Communicator* get_communicator(const size_t thread_id = 0) const {
+        assert(thread_id < num_threads);
+        return workers[thread_id].getCommunicator();
+    }
+
     /**
      * Print the number of bytes sent by each communicator.
      */
@@ -990,7 +995,9 @@ class RunTime {
 
         size_t total_bytes_sent = 0;
         for (int i = 0; i < num_threads; ++i) {
-            size_t bytes_sent = communicators[i]->getBytesSent();
+            auto communicator = get_communicator(i);
+
+            size_t bytes_sent = communicator->getBytesSent();
             total_bytes_sent += bytes_sent;
 
             std::cout << _spacer << std::setw(lhs_width) << std::left


### PR DESCRIPTION
This commit fixes `print_communicator_statistics()` method in `RunTime` class.

**Issue replication steps:**
```bash
$ cd build
$ cmake .. -DPROTOCOL=3 -DEXTRA="-DPRINT_COMMUNICATOR_STATISTICS"
$ make -j 16
```
**Compiler report:**
```
In file included from /home/user/orq/include/mpc.h:4,
                 from /home/user/orq/include/orq.h:14,
                 from /home/user/orq/bench/micro/micro_merge.cpp:1:
/home/user/orq/include/backend/common/runtime.h: In member function ‘void orq::service::RunTime::print_communicator_statistics()’:
/home/user/orq/include/backend/common/runtime.h:993:33: error: ‘communicators’ was not declared in this scope; did you mean ‘Communicator’?
  993 |             size_t bytes_sent = communicators[i]->getBytesSent();
      |                                 ^~~~~~~~~~~~~
      |                                 Communicator
```